### PR TITLE
Fix infinite loop against /stake-accounts API

### DIFF
--- a/src/components/WalletStatus.js
+++ b/src/components/WalletStatus.js
@@ -1,7 +1,7 @@
 "use client";
 
 import "../styles.css";
-import React, { useState, useEffect, useCallback, memo } from "react";
+import React, { useState, useEffect, useCallback, memo, useMemo } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
@@ -124,13 +124,12 @@ const StakedBalances = memo(({ publicKey, connection, onBalanceClick, refreshCou
   const [isFirstLoad, setIsFirstLoad] = useState(true);
   const [totalStakeRewards, setTotalStakeRewards] = useState("0.00");
 
-  const mintAddresses = TOKEN_LIST.filter((token) => token.mintAddress).reduce(
-    (acc, token) => {
+  const mintAddresses = useMemo(() => {
+    return TOKEN_LIST.filter((token) => token.mintAddress).reduce((acc, token) => {
       acc[token.name] = token.mintAddress;
       return acc;
-    },
-    {}
-  );
+    }, {});
+  }, []);
 
   const formatFullPrecision = (number) => {
     const str = number.toString();


### PR DESCRIPTION
Problem: `/stake-accounts` gets called in an infinite loop, mini-DDoSing the server.

Solution: The issue you're encountering with fetchStakedBalances being called in an infinite loop is likely due to how the dependencies are managed in your StakedBalances component. Specifically, the mintAddresses object is recreated on every render, which triggers the useCallback hook to regenerate fetchStakedBalances, leading to the infinite loop.

1. Understanding the Problem
In your StakedBalances component, you have the following useCallback hook:
The dependencies array includes mintAddresses. However, mintAddresses is defined as:
Every time the component renders, a new object is created for mintAddresses. This means that fetchStakedBalances is considered a new function on every render because one of its dependencies (mintAddresses) changes. Consequently, the useEffect that depends on fetchStakedBalances gets triggered again, causing an infinite loop.

2. Solution: Memoize mintAddresses
To prevent mintAddresses from being recreated on every render, you should memoize it using the useMemo hook. This ensures that mintAddresses only changes when its actual dependencies change.
